### PR TITLE
feat: refactor redis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ asyncio_mode = "auto"
 timeout = 5
 pythonpath = ["."]
 testpaths = ["tests"]
-addopts = ["--import-mode=importlib"]
+addopts = ["--import-mode=importlib", "--basetemp=.pytest_tmp"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/src/domains/data_import/parser/csv_reader.py
+++ b/src/domains/data_import/parser/csv_reader.py
@@ -23,6 +23,12 @@ class CSVParser:
                 return "utf-8"
             if raw_data.startswith(b"\xef\xbb\xbf"):
                 return "utf-8-sig"
+            for encoding in ("utf-8", "utf-8-sig"):
+                try:
+                    raw_data.decode(encoding)
+                    return encoding
+                except UnicodeDecodeError:
+                    continue
             result = chardet.detect(raw_data)
             detected = result.get("encoding")
             confidence = result.get("confidence") or 0

--- a/src/domains/data_import/service.py
+++ b/src/domains/data_import/service.py
@@ -267,7 +267,7 @@ class ImportService:
         batch_details: list[dict[str, Any]] = []
 
         for i, row in enumerate(rows):
-            if await self._is_cancelled(import_id):
+            if i > 0 and i % batch_size == 0 and await self._is_cancelled(import_id):
                 await self.repo.update_status(import_id, ImportStatus.CANCELLED)
                 await self.session.commit()
                 return {"cancelled": True}

--- a/src/domains/data_import/service.py
+++ b/src/domains/data_import/service.py
@@ -267,7 +267,7 @@ class ImportService:
         batch_details: list[dict[str, Any]] = []
 
         for i, row in enumerate(rows):
-            if i > 0 and i % batch_size == 0 and await self._is_cancelled(import_id):
+            if await self._is_cancelled(import_id):
                 await self.repo.update_status(import_id, ImportStatus.CANCELLED)
                 await self.session.commit()
                 return {"cancelled": True}

--- a/src/shared/idempotency.py
+++ b/src/shared/idempotency.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Any
 
-from redis.exceptions import RedisError
+from redis.exceptions import RedisError, ResponseError, WatchError
 
 from src.cache import resolve_sync_redis_client
 
@@ -12,6 +12,13 @@ logger = logging.getLogger(__name__)
 
 
 class FunboostIdempotencyHelper:
+    _EVAL_UNSUPPORTED_MARKERS = (
+        "unknown command",
+        "unsupported",
+        "not supported",
+        "lua scripts are disabled",
+        "lua scripting is disabled",
+    )
     _REFRESH_SCRIPT = """
     if redis.call('get', KEYS[1]) == ARGV[1] then
         return redis.call('expire', KEYS[1], ARGV[2])
@@ -47,6 +54,79 @@ class FunboostIdempotencyHelper:
             runner = register_script(script)
             return runner(keys=[lock_key], args=list(args), client=self.redis)
 
+    @classmethod
+    def _is_eval_unsupported_error(cls, exc: RedisError) -> bool:
+        if not isinstance(exc, ResponseError):
+            return False
+        message = str(exc).lower()
+        return any(marker in message for marker in cls._EVAL_UNSUPPORTED_MARKERS)
+
+    @staticmethod
+    def _token_matches(current: Any, token: str) -> bool:
+        if isinstance(current, bytes):
+            current = current.decode()
+        return current == token
+
+    def _make_transaction_pipeline(self) -> Any | None:
+        pipeline_factory = getattr(self.redis, "pipeline", None)
+        if not callable(pipeline_factory):
+            return None
+        try:
+            return pipeline_factory(transaction=True)
+        except TypeError:
+            return pipeline_factory()
+
+    def _refresh_lock_with_transaction(
+        self, lock_key: str, token: str, new_ttl: int
+    ) -> bool:
+        pipeline = self._make_transaction_pipeline()
+        if pipeline is None:
+            return False
+        required_methods = ("watch", "get", "multi", "expire", "execute")
+        if any(
+            not callable(getattr(pipeline, method, None)) for method in required_methods
+        ):
+            return False
+        try:
+            pipeline.watch(lock_key)
+            if not self._token_matches(pipeline.get(lock_key), token):
+                return False
+            pipeline.multi()
+            pipeline.expire(lock_key, int(new_ttl))
+            results = pipeline.execute()
+            return bool(results[-1]) if results else False
+        except WatchError:
+            return False
+        except RedisError:
+            return False
+        finally:
+            reset = getattr(pipeline, "reset", None)
+            if callable(reset):
+                reset()
+
+    def _release_lock_with_transaction(self, lock_key: str, token: str) -> None:
+        pipeline = self._make_transaction_pipeline()
+        if pipeline is None:
+            return
+        required_methods = ("watch", "get", "multi", "delete", "execute")
+        if any(
+            not callable(getattr(pipeline, method, None)) for method in required_methods
+        ):
+            return
+        try:
+            pipeline.watch(lock_key)
+            if not self._token_matches(pipeline.get(lock_key), token):
+                return
+            pipeline.multi()
+            pipeline.delete(lock_key)
+            pipeline.execute()
+        except (WatchError, RedisError):
+            return
+        finally:
+            reset = getattr(pipeline, "reset", None)
+            if callable(reset):
+                reset()
+
     def acquire_lock(self, key: str, ttl: int) -> str | None:
         token = binascii.hexlify(os.urandom(16)).decode()
         acquired = self.redis.set(self._lock_key(key), token, ex=ttl, nx=True)
@@ -61,8 +141,10 @@ class FunboostIdempotencyHelper:
                 token,
                 new_ttl,
             )
-        except RedisError:
-            return False
+        except RedisError as exc:
+            if not self._is_eval_unsupported_error(exc):
+                return False
+            return self._refresh_lock_with_transaction(lock_key, token, new_ttl)
         return bool(result)
 
     def release_lock(self, key: str, token: str) -> None:
@@ -74,7 +156,10 @@ class FunboostIdempotencyHelper:
                 token,
             )
             return
-        except RedisError:
+        except RedisError as exc:
+            if self._is_eval_unsupported_error(exc):
+                self._release_lock_with_transaction(lock_key, token)
+                return
             logger.error(
                 "failed to release idempotency lock task_name=%s key=%s",
                 self.task_name,

--- a/src/tasks/worker.py
+++ b/src/tasks/worker.py
@@ -16,6 +16,8 @@ from src.tasks.etl import products as etl_products
 
 logger = logging.getLogger(__name__)
 
+_MULTIPROCESS_QUEUES = frozenset({"etl_orders", "etl_products"})
+
 
 def _queue_runners(etl_processes: int) -> dict[str, Callable[[], None]]:
     return {
@@ -48,6 +50,10 @@ def _start_runner_thread(queue_name: str, runner: Callable[[], None]) -> Thread:
     thread = Thread(target=runner, name=f"worker-{queue_name}", daemon=True)
     thread.start()
     return thread
+
+
+def _runner_thread_to_watch(queue_name: str, thread: Thread) -> Thread | None:
+    return None if queue_name in _MULTIPROCESS_QUEUES else thread
 
 
 def _wait_forever(
@@ -162,7 +168,9 @@ def main() -> None:
             if runner is None:
                 raise ValueError(f"unsupported queue name: {args.queue}")
             runner_thread = _start_runner_thread(args.queue, runner)
-            _wait_forever(stop_event, runner_thread)
+            _wait_forever(
+                stop_event, _runner_thread_to_watch(args.queue, runner_thread)
+            )
         else:
             run_all(etl_processes=args.etl_processes, stop_event=stop_event)
     finally:

--- a/src/tasks/worker.py
+++ b/src/tasks/worker.py
@@ -52,8 +52,11 @@ def _start_runner_thread(queue_name: str, runner: Callable[[], None]) -> Thread:
     return thread
 
 
-def _runner_thread_to_watch(queue_name: str, thread: Thread) -> Thread | None:
-    return None if queue_name in _MULTIPROCESS_QUEUES else thread
+def _start_queue(queue_name: str, runner: Callable[[], None]) -> Thread | None:
+    if queue_name in _MULTIPROCESS_QUEUES:
+        runner()
+        return None
+    return _start_runner_thread(queue_name, runner)
 
 
 def _wait_forever(
@@ -82,7 +85,9 @@ def _wait_forever(
 def run_all(etl_processes: int = 2, *, stop_event: Event | None = None) -> None:
     threads: list[Thread] = []
     for queue_name, runner in _queue_runners(etl_processes).items():
-        threads.append(_start_runner_thread(queue_name, runner))
+        thread = _start_queue(queue_name, runner)
+        if thread is not None:
+            threads.append(thread)
 
     if stop_event is None:
         _wait_forever(threads=threads)
@@ -167,10 +172,8 @@ def main() -> None:
             runner = _queue_runners(args.etl_processes).get(args.queue)
             if runner is None:
                 raise ValueError(f"unsupported queue name: {args.queue}")
-            runner_thread = _start_runner_thread(args.queue, runner)
-            _wait_forever(
-                stop_event, _runner_thread_to_watch(args.queue, runner_thread)
-            )
+            runner_thread = _start_queue(args.queue, runner)
+            _wait_forever(stop_event, runner_thread)
         else:
             run_all(etl_processes=args.etl_processes, stop_event=stop_event)
     finally:

--- a/src/tasks/worker.py
+++ b/src/tasks/worker.py
@@ -51,12 +51,18 @@ def _start_runner_thread(queue_name: str, runner: Callable[[], None]) -> Thread:
 
 
 def _wait_forever(
-    stop_event: Event | None = None, threads: Sequence[Thread] | None = None
+    stop_event: Event | None = None,
+    threads: Sequence[Thread] | Thread | None = None,
 ) -> None:
     worker_stop_event = stop_event or Event()
+    thread_list = (
+        list(threads)
+        if isinstance(threads, Sequence)
+        else ([threads] if threads is not None else [])
+    )
     try:
         while not worker_stop_event.wait(5):
-            for thread in threads or ():
+            for thread in thread_list:
                 if not thread.is_alive():
                     logger.error(
                         "worker thread exited unexpectedly name=%s", thread.name

--- a/tests/cache/test_local_cache.py
+++ b/tests/cache/test_local_cache.py
@@ -2,6 +2,8 @@ import asyncio
 
 import pytest
 
+from src.cache.local import LocalCache
+
 
 async def test_set_get(local_cache):
     await local_cache.set("key1", "value1")
@@ -25,6 +27,36 @@ async def test_set_with_ttl(local_cache):
 async def test_set_with_zero_ttl_raises(local_cache):
     with pytest.raises(ValueError, match="ttl must be greater than 0"):
         await local_cache.set("key_ttl_zero", "value", ttl=0)
+
+
+async def test_max_entries_evicts_oldest_key():
+    cache = LocalCache(max_entries=2)
+    try:
+        await cache.set("key1", "value1")
+        await cache.set("key2", "value2")
+        await cache.set("key3", "value3")
+
+        assert await cache.get("key1") is None
+        assert await cache.get("key2") == "value2"
+        assert await cache.get("key3") == "value3"
+    finally:
+        await cache.close()
+
+
+async def test_get_refreshes_lru_recency():
+    cache = LocalCache(max_entries=2)
+    try:
+        await cache.set("key1", "value1")
+        await cache.set("key2", "value2")
+        assert await cache.get("key1") == "value1"
+
+        await cache.set("key3", "value3")
+
+        assert await cache.get("key1") == "value1"
+        assert await cache.get("key2") is None
+        assert await cache.get("key3") == "value3"
+    finally:
+        await cache.close()
 
 
 async def test_delete(local_cache):

--- a/tests/tasks/test_base_task_status.py
+++ b/tests/tasks/test_base_task_status.py
@@ -1,8 +1,9 @@
-from types import SimpleNamespace
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pytest
 
+from src import session as session_module
 from src.config import get_settings
 from src.domains.task.enums import (
     TaskDefinitionStatus,
@@ -11,7 +12,6 @@ from src.domains.task.enums import (
     TaskType,
 )
 from src.domains.task.models import TaskDefinition, TaskExecution
-from src import session as session_module
 from src.tasks.base import TaskStatusMixin
 from src.tasks.funboost_compat import FunctionResultStatus
 from src.tasks.status_store import (
@@ -33,7 +33,43 @@ class FakeRedis:
         self.expire_calls.append((key, seconds))
 
 
-class FakePipeline:
+class RecordingPipeline:
+    def __init__(self, redis):
+        self.redis = redis
+        self.commands = []
+
+    def hset(self, key, mapping):
+        self.commands.append(("hset", key, mapping))
+        return self
+
+    def expire(self, key, seconds):
+        self.commands.append(("expire", key, seconds))
+        return self
+
+    def execute(self):
+        self.redis.executed_batches.append(list(self.commands))
+        for command in self.commands:
+            if command[0] == "hset":
+                _, key, mapping = command
+                self.redis.hset(key, mapping)
+            if command[0] == "expire":
+                _, key, seconds = command
+                self.redis.expire(key, seconds)
+        return [True for _ in self.commands]
+
+
+class FakePipelineRedis(FakeRedis):
+    def __init__(self):
+        super().__init__()
+        self.executed_batches = []
+        self.pipeline_transactions = []
+
+    def pipeline(self, transaction=True):
+        self.pipeline_transactions.append(transaction)
+        return RecordingPipeline(self)
+
+
+class FailingPipeline:
     def __init__(self, raise_on_execute=False):
         self.raise_on_execute = raise_on_execute
         self.closed = False
@@ -60,6 +96,25 @@ class PipelineRedis:
     def pipeline(self, transaction=True):
         _ = transaction
         return self._pipeline
+
+
+def test_write_status_mapping_uses_pipeline_transaction():
+    fake_redis = FakePipelineRedis()
+    ttl = get_settings().funboost.status_ttl_seconds
+
+    _write_status_mapping(fake_redis, "status-key", {"status": "STARTED", 1: "value"})
+
+    assert fake_redis.pipeline_transactions == [True]
+    assert fake_redis.executed_batches == [
+        [
+            ("hset", "status-key", {"status": "STARTED", "1": "value"}),
+            ("expire", "status-key", ttl),
+        ]
+    ]
+    assert fake_redis.hset_calls == [
+        ("status-key", {"status": "STARTED", "1": "value"})
+    ]
+    assert fake_redis.expire_calls == [("status-key", ttl)]
 
 
 def test_task_status_hook_writes_fields_and_ttl():
@@ -138,7 +193,7 @@ def test_write_finished_task_status_ignores_interpreter_shutdown(monkeypatch):
 
 
 def test_write_status_mapping_closes_pipeline_on_error():
-    pipeline = FakePipeline(raise_on_execute=True)
+    pipeline = FailingPipeline(raise_on_execute=True)
 
     with pytest.raises(RuntimeError, match="pipeline execute failed"):
         _write_status_mapping(

--- a/tests/tasks/test_idempotency.py
+++ b/tests/tasks/test_idempotency.py
@@ -3,7 +3,8 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
 import fakeredis
-from redis.exceptions import RedisError
+import pytest
+from redis.exceptions import RedisError, ResponseError, WatchError
 
 from src.scrapers.shop_dashboard.runtime import ShopDashboardRuntimeConfig
 from src.tasks.collection import douyin_shop_dashboard as collection_module
@@ -129,6 +130,122 @@ def test_idempotency_cache_result_handles_redis_error(caplog):
         helper.cache_result("shop-1:2026-03-03", {"status": "success"})
 
     assert "failed to cache idempotency result" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "unknown command 'eval'",
+        "lua scripts are disabled",
+    ],
+)
+def test_idempotency_eval_unsupported_fallback_uses_transaction(error_message):
+    redis_client = fakeredis.FakeRedis(decode_responses=True)
+    helper = FunboostIdempotencyHelper(redis_client, "sync_shop_dashboard")
+    business_key = "shop-1:2026-03-04"
+    lock_key = f"douyin:lock:sync_shop_dashboard:{business_key}"
+
+    def _raise_eval_unsupported(*_args):
+        raise ResponseError(error_message)
+
+    redis_client.eval = _raise_eval_unsupported
+
+    token = helper.acquire_lock(business_key, ttl=120)
+    assert token is not None
+
+    assert helper.refresh_lock(business_key, token, 600)
+    assert redis_client.ttl(lock_key) > 120
+
+    helper.release_lock(business_key, token)
+    assert redis_client.get(lock_key) is None
+
+
+class _TransientEvalRedis:
+    def __init__(self):
+        self.get_calls = 0
+        self.expire_calls = 0
+        self.delete_calls = 0
+
+    def eval(self, *_args):
+        raise RedisError("connection lost")
+
+    def get(self, _key):
+        self.get_calls += 1
+        raise AssertionError("transient eval failure must not call get")
+
+    def expire(self, *_args):
+        self.expire_calls += 1
+        raise AssertionError("transient eval failure must not call expire")
+
+    def delete(self, *_args):
+        self.delete_calls += 1
+        raise AssertionError("transient eval failure must not call delete")
+
+
+def test_idempotency_transient_eval_error_does_not_use_non_atomic_fallback():
+    redis_client = _TransientEvalRedis()
+    helper = FunboostIdempotencyHelper(redis_client, "sync_shop_dashboard")
+
+    assert not helper.refresh_lock("shop-1:2026-03-05", "token-a", 600)
+    helper.release_lock("shop-1:2026-03-05", "token-a")
+
+    assert redis_client.get_calls == 0
+    assert redis_client.expire_calls == 0
+    assert redis_client.delete_calls == 0
+
+
+class _RacingPipeline:
+    def __init__(self, redis_client):
+        self.redis_client = redis_client
+        self.key = ""
+
+    def watch(self, key):
+        self.key = key
+
+    def get(self, key):
+        return self.redis_client.store.get(key)
+
+    def multi(self):
+        self.redis_client.store[self.key] = "token-b"
+
+    def expire(self, *_args):
+        return None
+
+    def delete(self, *_args):
+        return None
+
+    def execute(self):
+        raise WatchError("lock owner changed")
+
+    def reset(self):
+        return None
+
+
+class _EvalUnsupportedRacingRedis:
+    def __init__(self):
+        self.store: dict[str, str] = {}
+
+    def eval(self, *_args):
+        raise ResponseError("unknown command 'eval'")
+
+    def pipeline(self, transaction=True):
+        assert transaction is True
+        return _RacingPipeline(self)
+
+
+def test_idempotency_transaction_fallback_does_not_mutate_new_owner_lock():
+    redis_client = _EvalUnsupportedRacingRedis()
+    helper = FunboostIdempotencyHelper(redis_client, "sync_shop_dashboard")
+    business_key = "shop-1:2026-03-06"
+    lock_key = f"douyin:lock:sync_shop_dashboard:{business_key}"
+    redis_client.store[lock_key] = "token-a"
+
+    assert not helper.refresh_lock(business_key, "token-a", 600)
+    assert redis_client.store[lock_key] == "token-b"
+
+    redis_client.store[lock_key] = "token-a"
+    helper.release_lock(business_key, "token-a")
+    assert redis_client.store[lock_key] == "token-b"
 
 
 def test_build_business_key_supports_extended_dedupe_variables():

--- a/tests/tasks/test_worker_entry.py
+++ b/tests/tasks/test_worker_entry.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+
+
 def test_tasks_package_imports_task_modules():
     import src.tasks as tasks
 
@@ -186,3 +189,59 @@ def test_worker_run_queue_supports_dead_letter_queue(monkeypatch):
 
     module.run_queue("etl_orders_dlx", etl_processes=2)
     assert calls == ["etl_orders_dlx"]
+
+
+def test_worker_main_keeps_etl_queue_alive_when_multiprocess_runner_returns(
+    monkeypatch,
+):
+    from src.tasks import worker as module
+
+    calls = []
+
+    monkeypatch.setattr(
+        module,
+        "_parse_args",
+        lambda: SimpleNamespace(queue="etl_orders", etl_processes=2),
+    )
+    monkeypatch.setattr(
+        module,
+        "_queue_runners",
+        lambda _etl_processes: {"etl_orders": lambda: calls.append("runner")},
+    )
+    monkeypatch.setattr(module, "_init_worker_db", lambda: calls.append("init_db"))
+    monkeypatch.setattr(module, "_close_worker_db", lambda: calls.append("close_db"))
+    monkeypatch.setattr(
+        module,
+        "_start_worker_loop",
+        lambda: (SimpleNamespace(), SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        module,
+        "_stop_worker_loop",
+        lambda _loop, _thread: calls.append("stop_loop"),
+    )
+    monkeypatch.setattr(module.signal, "signal", lambda *_args: None)
+
+    class _FakeThread:
+        def __init__(self, target, name, daemon=False):
+            self._target = target
+            self.name = name
+
+        def start(self):
+            self._target()
+
+        def is_alive(self):
+            return False
+
+    def _fake_wait(stop_event, thread=None):
+        calls.append(("wait", thread))
+        stop_event.set()
+
+    monkeypatch.setattr(module, "Thread", _FakeThread)
+    monkeypatch.setattr(module, "_wait_forever", _fake_wait)
+
+    module.main()
+
+    assert calls[0:2] == ["init_db", "runner"]
+    assert ("wait", None) in calls
+    assert calls[-2:] == ["close_db", "stop_loop"]

--- a/tests/tasks/test_worker_entry.py
+++ b/tests/tasks/test_worker_entry.py
@@ -1,3 +1,4 @@
+import pytest
 from types import SimpleNamespace
 
 
@@ -89,7 +90,15 @@ def test_worker_run_all_dispatches_consumers(monkeypatch):
 
     module.run_all(etl_processes=2)
     assert len(calls) == 8
-    assert len(waited_threads) == 8
+    assert len(waited_threads) == 6
+    assert {thread.name for thread in waited_threads} == {
+        "worker-collection_shop_dashboard",
+        "worker-collection_shop_dashboard_agent",
+        "worker-collection_shop_dashboard_dlx",
+        "worker-collection_shop_dashboard_agent_dlx",
+        "worker-etl_orders_dlx",
+        "worker-etl_products_dlx",
+    }
     assert {
         "collection_shop_dashboard",
         "collection_shop_dashboard_agent",
@@ -176,6 +185,30 @@ def test_worker_run_all_keeps_parent_alive_when_multiprocess_runner_returns(
     assert calls == ["etl_orders", "wait_forever"]
 
 
+def test_worker_run_all_raises_when_multiprocess_runner_fails_to_start(monkeypatch):
+    from src.tasks import worker as module
+
+    calls = []
+
+    def _raise() -> None:
+        calls.append("runner")
+        raise RuntimeError("startup failed")
+
+    monkeypatch.setattr(
+        module,
+        "_queue_runners",
+        lambda _etl_processes: {"etl_orders": _raise},
+    )
+    monkeypatch.setattr(
+        module, "_wait_forever", lambda *_args, **_kwargs: calls.append("wait_forever")
+    )
+
+    with pytest.raises(RuntimeError, match="startup failed"):
+        module.run_all(etl_processes=2)
+
+    assert calls == ["runner"]
+
+
 def test_worker_run_queue_supports_dead_letter_queue(monkeypatch):
     from src.tasks import worker as module
 
@@ -245,3 +278,45 @@ def test_worker_main_keeps_etl_queue_alive_when_multiprocess_runner_returns(
     assert calls[0:2] == ["init_db", "runner"]
     assert ("wait", None) in calls
     assert calls[-2:] == ["close_db", "stop_loop"]
+
+
+def test_worker_main_raises_when_etl_queue_startup_fails(monkeypatch):
+    from src.tasks import worker as module
+
+    calls = []
+
+    def _raise() -> None:
+        calls.append("runner")
+        raise RuntimeError("startup failed")
+
+    monkeypatch.setattr(
+        module,
+        "_parse_args",
+        lambda: SimpleNamespace(queue="etl_orders", etl_processes=2),
+    )
+    monkeypatch.setattr(
+        module,
+        "_queue_runners",
+        lambda _etl_processes: {"etl_orders": _raise},
+    )
+    monkeypatch.setattr(module, "_init_worker_db", lambda: calls.append("init_db"))
+    monkeypatch.setattr(module, "_close_worker_db", lambda: calls.append("close_db"))
+    monkeypatch.setattr(
+        module,
+        "_start_worker_loop",
+        lambda: (SimpleNamespace(), SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        module,
+        "_stop_worker_loop",
+        lambda _loop, _thread: calls.append("stop_loop"),
+    )
+    monkeypatch.setattr(module.signal, "signal", lambda *_args: None)
+    monkeypatch.setattr(
+        module, "_wait_forever", lambda *_args, **_kwargs: calls.append("wait_forever")
+    )
+
+    with pytest.raises(RuntimeError, match="startup failed"):
+        module.main()
+
+    assert calls == ["init_db", "runner", "close_db", "stop_loop"]


### PR DESCRIPTION
## Related Issue

Closes #N/A

## Summary of Changes

- Fixed `LocalCache` TTL handling and added bounded LRU-style eviction to prevent unbounded in-memory growth.
- Hardened Redis cache and idempotency behavior by isolating PubSub subscriptions, encoding Redis passwords in generated URLs, and adding safe fallback handling for Lua lock refresh/release failures.
- Made task status writes atomic with Redis pipelines, updated worker shutdown flow to use event-driven signal handling, and removed the hardcoded Alembic revision hint from beat startup errors.

## Breaking Changes

N/A

## Checklist

- [ ] Issue discussion completed before opening PR
- [x] Scope is small and focused (single feature/fix)
- [x] All functions have full type annotations
- [ ] Async/await used for all I/O operations
- [ ] Tests added for new behaviors