### PR TITLE
fix(collection): harden shop dashboard collection flow

### DIFF
--- a/src/application/collection/contracts.py
+++ b/src/application/collection/contracts.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable
 from collections.abc import Mapping
 from contextlib import AbstractAsyncContextManager
 from typing import Any
@@ -16,18 +15,18 @@ class SessionFactory(Protocol):
 
 
 class Bootstrapper(Protocol):
-    def bootstrap_shops(
+    async def bootstrap_shops(
         self,
         *,
         runtime: ShopDashboardRuntimeConfig,
         shop_ids: list[str],
         verify_metric_date_by_shop: Mapping[str, str] | None = None,
-    ) -> dict[str, dict[str, Any]] | Awaitable[dict[str, dict[str, Any]]]: ...
+    ) -> dict[str, dict[str, Any]]: ...
 
-    def bootstrap_shop(
+    async def bootstrap_shop(
         self,
         *,
         runtime: ShopDashboardRuntimeConfig,
         shop_id: str,
         verify_metric_date: str | None = None,
-    ) -> dict[str, Any] | Awaitable[dict[str, Any]]: ...
+    ) -> dict[str, Any]: ...

--- a/src/application/collection/executor.py
+++ b/src/application/collection/executor.py
@@ -84,7 +84,13 @@ class TaskModuleCollectionExecutor:
         self,
         policy: int | dict[str, Any] | None,
     ) -> RateLimiterProtocol:
-        rate_limiter_cls = getattr(self._task_module, "_RateLimiter")
+        rate_limiter_cls = _resolve_task_module_symbol(
+            self._task_module,
+            "_RateLimiter",
+            "RateLimiter",
+        )
+        if not callable(rate_limiter_cls):
+            raise AttributeError("missing rate limiter implementation")
         return rate_limiter_cls(policy)
 
     def create_idempotency_helper(
@@ -163,7 +169,13 @@ class TaskModuleCollectionExecutor:
         plan_unit: Any | None = None,
         queue_task_id: str | None = None,
     ) -> str:
-        build_business_key = getattr(self._task_module, "_build_business_key")
+        build_business_key = _resolve_task_module_symbol(
+            self._task_module,
+            "_build_business_key",
+            "build_business_key",
+        )
+        if not callable(build_business_key):
+            raise AttributeError("missing business key builder")
         return str(
             build_business_key(
                 runtime,
@@ -182,26 +194,34 @@ class TaskModuleCollectionExecutor:
         state_store: SessionStateStore,
         login_state_manager: LoginStateManager,
     ) -> dict[str, Any]:
-        collect_one_day = getattr(self._task_module, "_collect_one_day")
-        if _supports_shared_helpers(collect_one_day):
-            return collect_one_day(
-                runtime,
-                metric_date,
-                lock_manager=lock_manager,
-                state_store=state_store,
-                login_state_manager=login_state_manager,
-            )
-        return collect_one_day(
-            runtime,
-            metric_date,
+        collect_one_day = _resolve_task_module_symbol(
+            self._task_module,
+            "_collect_one_day",
+            "collect_one_day",
         )
+        if not callable(collect_one_day):
+            raise AttributeError("missing collection entrypoint")
+        keyword_args = {
+            "lock_manager": lock_manager,
+            "state_store": state_store,
+            "login_state_manager": login_state_manager,
+        }
+        if _supports_shared_helpers(collect_one_day):
+            return collect_one_day(runtime, metric_date, **keyword_args)
+        if _signature_unavailable(collect_one_day):
+            try:
+                return collect_one_day(runtime, metric_date, **keyword_args)
+            except TypeError as exc:
+                if not _is_unexpected_keyword_error(exc, keyword_args):
+                    raise
+        return collect_one_day(runtime, metric_date)
 
 
 def _supports_shared_helpers(collector: Any) -> bool:
     try:
         signature = inspect.signature(collector)
     except (TypeError, ValueError):
-        return True
+        return False
     parameters = signature.parameters
     if any(
         parameter.kind == inspect.Parameter.VAR_KEYWORD
@@ -210,3 +230,33 @@ def _supports_shared_helpers(collector: Any) -> bool:
         return True
     required = {"lock_manager", "state_store", "login_state_manager"}
     return required.issubset(parameters.keys())
+
+
+def _signature_unavailable(call: Any) -> bool:
+    try:
+        inspect.signature(call)
+    except (TypeError, ValueError):
+        return True
+    return False
+
+
+def _is_unexpected_keyword_error(exc: TypeError, keyword_args: dict[str, Any]) -> bool:
+    message = str(exc)
+    if "unexpected keyword argument" not in message:
+        return False
+    return any(name in message for name in keyword_args)
+
+
+def _resolve_task_module_symbol(task_module: Any, *names: str) -> Any:
+    for module in (task_module, _default_task_module()):
+        for name in names:
+            value = getattr(module, name, None)
+            if value is not None:
+                return value
+    return None
+
+
+def _default_task_module() -> Any:
+    from src.tasks.collection import douyin_shop_dashboard as task_module
+
+    return task_module

--- a/src/application/collection/result_persister.py
+++ b/src/application/collection/result_persister.py
@@ -141,7 +141,6 @@ class CollectionResultPersister:
                 resolved_shop_id,
                 metric_day_text,
             )
-            raise
 
     async def _invalidate_experience_cache(
         self,

--- a/src/application/collection/result_persister.py
+++ b/src/application/collection/result_persister.py
@@ -141,6 +141,7 @@ class CollectionResultPersister:
                 resolved_shop_id,
                 metric_day_text,
             )
+            raise
 
     async def _invalidate_experience_cache(
         self,

--- a/src/application/collection/usecase.py
+++ b/src/application/collection/usecase.py
@@ -669,6 +669,13 @@ class CollectionUseCase:
                     bootstrap_result.get("error_code") or "verify_request_failed"
                 ).strip()
                 bootstrap_error = str(bootstrap_result.get("error") or "").strip()
+                if bootstrap_error_code == "verify_login_expired":
+                    mark_expired = getattr(login_state_manager, "mark_expired", None)
+                    if callable(mark_expired):
+                        await mark_expired(
+                            storage_account_id,
+                            reason=bootstrap_error_code,
+                        )
                 bootstrap_verify_failed_count += 1
                 observe_shop_dashboard_bootstrap_verify_failed(
                     error_code=bootstrap_error_code

--- a/src/application/collection/usecase.py
+++ b/src/application/collection/usecase.py
@@ -53,6 +53,8 @@ from src.shared.redis_keys import redis_keys
 
 logger = logging.getLogger(__name__)
 
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
 
 def _ensure_db_initialized() -> None:
     if session.async_session_factory is not None:
@@ -66,6 +68,16 @@ async def _ensure_db_initialized_async() -> None:
         return
     settings = get_settings()
     await session.init_db(settings.db.url, settings.db.echo)
+
+
+def _resolve_state_store_base_dir() -> Path:
+    configured = str(get_settings().shop_dashboard.runtime_state_dir or "").strip()
+    if not configured:
+        return _REPO_ROOT / ".runtime" / "shop_dashboard_state"
+    state_dir = Path(configured).expanduser()
+    if state_dir.is_absolute():
+        return state_dir
+    return _REPO_ROOT / state_dir
 
 
 class CollectionUseCase:
@@ -499,7 +511,7 @@ class CollectionUseCase:
             task_name="sync_shop_dashboard",
         )
         state_store = self.executor.create_state_store(
-            base_dir=Path(".runtime") / "shop_dashboard_state"
+            base_dir=_resolve_state_store_base_dir()
         )
         runtime = self.executor.materialize_runtime_storage_state(
             runtime=runtime,
@@ -775,6 +787,9 @@ class CollectionUseCase:
                     "reason": "running",
                     "metric_date": plan_unit.metric_date,
                     "shop_id": unit_runtime.shop_id,
+                    "target_shop_id": unit_runtime.shop_id,
+                    "actual_shop_id": None,
+                    "mismatch_status": "unknown",
                     "rule_id": unit_runtime.rule_id,
                     "execution_id": unit_runtime.execution_id,
                     "retry_count": 0,
@@ -1319,14 +1334,13 @@ class CollectionUseCase:
             "runtime": runtime,
             "shop_ids": shop_ids,
         }
-        if self._supports_keyword_argument(
-            bootstrap_shops,
-            "verify_metric_date_by_shop",
-        ):
-            kwargs["verify_metric_date_by_shop"] = dict(verify_metric_date_by_shop)
-        result = bootstrap_shops(**kwargs)
-        if inspect.isawaitable(result):
-            result = await result
+        result = await self._invoke_with_optional_kwargs(
+            call=bootstrap_shops,
+            kwargs=kwargs,
+            optional_kwargs={
+                "verify_metric_date_by_shop": dict(verify_metric_date_by_shop)
+            },
+        )
         if isinstance(result, dict):
             return result
         return {}
@@ -1344,11 +1358,11 @@ class CollectionUseCase:
             "runtime": runtime,
             "shop_id": shop_id,
         }
-        if self._supports_keyword_argument(bootstrap_shop, "verify_metric_date"):
-            kwargs["verify_metric_date"] = verify_metric_date
-        result = bootstrap_shop(**kwargs)
-        if inspect.isawaitable(result):
-            result = await result
+        result = await self._invoke_with_optional_kwargs(
+            call=bootstrap_shop,
+            kwargs=kwargs,
+            optional_kwargs={"verify_metric_date": verify_metric_date},
+        )
         if isinstance(result, dict):
             return result
         return {
@@ -1360,15 +1374,58 @@ class CollectionUseCase:
             "error_code": "verify_request_failed",
         }
 
-    def _supports_keyword_argument(self, call: Any, argument_name: str) -> bool:
+    async def _invoke_with_optional_kwargs(
+        self,
+        *,
+        call: Any,
+        kwargs: dict[str, Any],
+        optional_kwargs: dict[str, Any],
+    ) -> Any:
+        merged = dict(kwargs)
         try:
             signature = inspect.signature(call)
         except (TypeError, ValueError):
-            return True
+            merged.update(optional_kwargs)
+            result = self._invoke_call(call=call, kwargs=merged)
+            if inspect.isawaitable(result):
+                return await result
+            return result
         for parameter in signature.parameters.values():
             if parameter.kind == inspect.Parameter.VAR_KEYWORD:
-                return True
-        return argument_name in signature.parameters
+                merged.update(optional_kwargs)
+                result = self._invoke_call(call=call, kwargs=merged)
+                if inspect.isawaitable(result):
+                    return await result
+                return result
+        for argument_name, value in optional_kwargs.items():
+            if argument_name in signature.parameters:
+                merged[argument_name] = value
+        result = self._invoke_call(call=call, kwargs=merged)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    def _invoke_call(self, *, call: Any, kwargs: dict[str, Any]) -> Any:
+        try:
+            return call(**kwargs)
+        except TypeError as exc:
+            if not self._is_unexpected_keyword_error(exc, kwargs):
+                raise
+            stripped_kwargs = {
+                key: value
+                for key, value in kwargs.items()
+                if key in {"runtime", "shop_ids", "shop_id"}
+            }
+            return call(**stripped_kwargs)
+
+    def _is_unexpected_keyword_error(
+        self, exc: TypeError, kwargs: dict[str, Any]
+    ) -> bool:
+        message = str(exc)
+        if "unexpected keyword argument" not in message:
+            return False
+        optional_names = set(kwargs) - {"runtime", "shop_ids", "shop_id"}
+        return any(name in message for name in optional_names)
 
     def _build_idempotency_key(
         self,

--- a/src/config/shop_dashboard.py
+++ b/src/config/shop_dashboard.py
@@ -3,6 +3,7 @@ from pydantic_settings import BaseSettings
 
 class ShopDashboardSettings(BaseSettings):
     base_url: str = "https://fxg.jinritemai.com"
+    runtime_state_dir: str = ".runtime/shop_dashboard_state"
     cookie_ttl_seconds: int = 21600
     lock_ttl_seconds: int = 3600
     shop_lock_ttl_seconds: int = 600

--- a/src/scrapers/shop_dashboard/http_scraper.py
+++ b/src/scrapers/shop_dashboard/http_scraper.py
@@ -21,6 +21,7 @@ from src.scrapers.shop_dashboard.parsers import (
     parse_violation_details,
     parse_violation_summary,
 )
+from src.scrapers.shop_dashboard.exceptions import LoginExpiredError
 from src.scrapers.shop_dashboard.exceptions import ShopDashboardScraperError
 from src.scrapers.shop_dashboard.query_builder import (
     build_endpoint_request_payload,
@@ -274,6 +275,8 @@ class HttpScraper:
                     max_retries=max_retries,
                 )
             except ShopDashboardScraperError as exc:
+                if isinstance(exc, LoginExpiredError):
+                    raise
                 if group_name in CORE_REQUIRED_GROUPS:
                     raise
                 payloads[group_name] = self._build_default_payload()
@@ -405,6 +408,17 @@ class HttpScraper:
                 path,
                 status_code,
             )
+            if status_code in {401, 403}:
+                raise LoginExpiredError(
+                    f"http_{status_code}",
+                    error_data={
+                        "method": method,
+                        "path": path,
+                        "url": url,
+                        "status_code": status_code,
+                        "response_body_snippet": response_body_snippet,
+                    },
+                ) from exc
             raise ShopDashboardScraperError(
                 "HTTP status error",
                 error_data={

--- a/src/scrapers/shop_dashboard/login_state_manager.py
+++ b/src/scrapers/shop_dashboard/login_state_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import time
 from collections.abc import Awaitable, Callable
@@ -30,10 +31,11 @@ class LoginStateManager:
             return False
 
         now = int(time.time())
-        state = self._get_state(account_id)
+        state = await self._get_state(account_id)
         last_probe_at = int(state.get("last_probe_at", "0") or "0")
         if (
-            self._probe_interval_seconds > 0
+            last_probe_at > 0
+            and self._probe_interval_seconds > 0
             and now - last_probe_at < self._probe_interval_seconds
         ):
             return state.get("status", "active") != "expired"
@@ -46,7 +48,7 @@ class LoginStateManager:
                 await self.mark_expired(account_id, reason="refresh_failed")
                 return False
 
-        self._set_state(
+        await self._set_state(
             account_id,
             {
                 "status": "active",
@@ -59,7 +61,7 @@ class LoginStateManager:
 
     async def mark_expired(self, account_id: str, reason: str) -> None:
         now = int(time.time())
-        self._set_state(
+        await self._set_state(
             account_id,
             {
                 "status": "expired",
@@ -71,17 +73,24 @@ class LoginStateManager:
     def _state_key(self, account_id: str) -> str:
         return f"{self._key_prefix}:{account_id}"
 
-    def _get_state(self, account_id: str) -> dict[str, str]:
+    async def _get_state(self, account_id: str) -> dict[str, str]:
         if self._redis is not None:
-            payload = self._redis.hgetall(self._state_key(account_id))
+            payload = await asyncio.to_thread(
+                self._redis.hgetall,
+                self._state_key(account_id),
+            )
             if isinstance(payload, dict):
                 return {str(k): str(v) for k, v in payload.items()}
             return {}
         return dict(self._memory_state.get(account_id, {}))
 
-    def _set_state(self, account_id: str, payload: dict[str, str]) -> None:
+    async def _set_state(self, account_id: str, payload: dict[str, str]) -> None:
         if self._redis is not None:
-            self._redis.hset(self._state_key(account_id), mapping=payload)
+            await asyncio.to_thread(
+                self._redis.hset,
+                self._state_key(account_id),
+                mapping=payload,
+            )
             return
         current = dict(self._memory_state.get(account_id, {}))
         current.update(payload)

--- a/src/scrapers/shop_dashboard/login_state_manager.py
+++ b/src/scrapers/shop_dashboard/login_state_manager.py
@@ -66,6 +66,7 @@ class LoginStateManager:
             {
                 "status": "expired",
                 "reason": str(reason),
+                "last_probe_at": str(now),
                 "updated_at": str(now),
             },
         )

--- a/src/scrapers/shop_dashboard/parsers.py
+++ b/src/scrapers/shop_dashboard/parsers.py
@@ -6,7 +6,7 @@ from typing import Any
 from src.scrapers.shop_dashboard.exceptions import LoginExpiredError
 from src.scrapers.shop_dashboard.exceptions import ShopDashboardScraperError
 
-LOGIN_EXPIRED_CODE = "10008"
+LOGIN_EXPIRED_CODES = frozenset({"10008", "401", "403"})
 
 
 def ensure_payload_success(payload: Mapping[str, Any]) -> None:
@@ -21,7 +21,7 @@ def ensure_payload_success(payload: Mapping[str, Any]) -> None:
     if code_str in {"0", "200"}:
         return
     message = str(payload.get("message", payload.get("msg", "scraping failed")))
-    if code_str == LOGIN_EXPIRED_CODE:
+    if code_str in LOGIN_EXPIRED_CODES:
         raise LoginExpiredError(
             "Login session expired",
             error_data={"code": code_str, "message": message},

--- a/src/scrapers/shop_dashboard/session_bootstrapper.py
+++ b/src/scrapers/shop_dashboard/session_bootstrapper.py
@@ -205,7 +205,13 @@ class SessionBootstrapper:
                 "bootstrap_verify_error_code": verify_error_code,
             }
         if isinstance(choose_result.cookies, dict) and choose_result.cookies:
-            unit_runtime.cookies.update(choose_result.cookies)
+            unit_runtime = replace(
+                unit_runtime,
+                cookies={
+                    **dict(unit_runtime.cookies or {}),
+                    **choose_result.cookies,
+                },
+            )
 
         verify_result = await self._verify_shop_context(
             runtime=unit_runtime,
@@ -643,7 +649,11 @@ def _with_target_shop_query(
     merged_query = dict(runtime.common_query or {})
     merged_query["shop_id"] = target_shop_id
     merged_query["subject_id"] = target_shop_id
-    return replace(runtime, common_query=merged_query)
+    return replace(
+        runtime,
+        cookies=dict(runtime.cookies or {}),
+        common_query=merged_query,
+    )
 
 
 def _is_bundle_for_target(

--- a/src/tasks/collection/douyin_shop_dashboard.py
+++ b/src/tasks/collection/douyin_shop_dashboard.py
@@ -12,7 +12,7 @@ from typing import Any
 from src.agents import LLMDashboardAgent
 from src.cache import resolve_sync_redis_client
 from src.config import get_settings
-from src.domains.shop_dashboard.repository import ShopDashboardRepository
+from src.scrapers.shop_dashboard.exceptions import LoginExpiredError
 from src.scrapers.shop_dashboard.http_scraper import HttpScraper
 from src.scrapers.shop_dashboard.lock_manager import LockManager
 from src.scrapers.shop_dashboard.login_state_manager import LoginStateManager
@@ -22,7 +22,6 @@ from src.scrapers.shop_dashboard.session_state_store import SessionStateStore
 from src.scrapers.shop_dashboard.shop_selection_validator import (
     normalize_shop_selection_payload,
 )
-from src.shared.payload_extractors import extract_nested_list
 from src import session
 from src.tasks.base import TaskStatusMixin, write_started_status_safe
 from src.tasks.exceptions import ScrapingFailedException
@@ -253,6 +252,7 @@ def _collect_one_day(
     settings = get_settings().shop_dashboard
     lock_manager = lock_manager or LockManager()
     account_id = _resolve_account_id(runtime)
+    _ensure_login_state_active(account_id, login_state_manager)
     shop_lock_id = _resolve_shop_lock_id(runtime.shop_id, account_id)
     last_error: Exception | None = None
     http_error: Exception | None = None
@@ -294,6 +294,13 @@ def _collect_one_day(
                             retry_count=retry_count,
                             fallback_trace=fallback_trace,
                         )
+                    except LoginExpiredError as exc:
+                        _mark_login_state_expired(
+                            account_id=account_id,
+                            login_state_manager=login_state_manager,
+                            reason=str(exc).strip() or "login_expired",
+                        )
+                        raise
                     except (ScrapingFailedException, ShopDashboardScraperError) as exc:
                         retry_count += 1
                         last_error = exc
@@ -327,6 +334,38 @@ def _collect_one_day(
             )
 
 
+def _ensure_login_state_active(
+    account_id: str,
+    login_state_manager: LoginStateManager | None,
+) -> None:
+    if login_state_manager is None:
+        return
+    check_and_refresh = getattr(login_state_manager, "check_and_refresh", None)
+    if not callable(check_and_refresh):
+        return
+    active = session.run_coro(check_and_refresh(account_id))
+    if active:
+        return
+    raise LoginExpiredError(
+        "login_state_expired",
+        error_data={"account_id": account_id},
+    )
+
+
+def _mark_login_state_expired(
+    *,
+    account_id: str,
+    login_state_manager: LoginStateManager | None,
+    reason: str,
+) -> None:
+    if login_state_manager is None:
+        return
+    mark_expired = getattr(login_state_manager, "mark_expired", None)
+    if not callable(mark_expired):
+        return
+    session.run_coro(mark_expired(account_id, reason))
+
+
 def _build_expired_account_result(
     runtime: ShopDashboardRuntimeConfig,
     metric_date: str,
@@ -351,6 +390,8 @@ def _build_expired_account_result(
         "reviews": {"summary": {}, "items": []},
         "violations": {"summary": {}, "waiting_list": []},
         "raw": {},
+        "retry_count": 0,
+        "fallback_trace": [],
     }
 
 
@@ -417,6 +458,7 @@ def _build_agent_fallback_result(
     fallback_trace: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     reason = _resolve_agent_reason(http_error)
+    trace = fallback_trace if isinstance(fallback_trace, list) else []
     payload: dict[str, Any] = {
         "status": "success",
         "source": "llm",
@@ -462,14 +504,14 @@ def _build_agent_fallback_result(
         payload["reason"] = "llm_failed"
         patched = payload
         _append_fallback_trace(
-            fallback_trace if isinstance(fallback_trace, list) else [],
+            trace,
             stage="agent",
             status="failed",
             error=llm_error if llm_error is not None else RuntimeError(failure_error),
         )
     else:
         _append_fallback_trace(
-            fallback_trace if isinstance(fallback_trace, list) else [],
+            trace,
             stage="agent",
             status="success",
         )
@@ -487,7 +529,7 @@ def _build_agent_fallback_result(
         metric_date,
         patched,
         retry_count=retry_count,
-        fallback_trace=fallback_trace,
+        fallback_trace=trace,
     )
 
 
@@ -592,148 +634,21 @@ async def _persist_result(
     metric_date: str,
     payload: dict[str, Any],
 ) -> None:
+    from src.application.collection.result_persister import CollectionResultPersister
+
     session_factory = session.async_session_factory
     if session_factory is None:
         return
     async with session_factory() as db_session:
-        repo = ShopDashboardRepository(db_session)
-        metric_day = date.fromisoformat(metric_date)
-        metric_day_text = metric_day.isoformat()
-        runtime_shop_id = _normalize_shop_id(runtime.shop_id)
-        actual_shop_id = _normalize_shop_id(
-            payload.get("actual_shop_id") or payload.get("shop_id") or runtime_shop_id
-        )
-        target_shop_id = _normalize_shop_id(
-            payload.get("target_shop_id") or runtime_shop_id
-        )
-        resolved_shop_id = actual_shop_id or runtime_shop_id
-        if not resolved_shop_id or not target_shop_id:
-            logger.warning(
-                "skip dashboard persistence due to empty shop key: target_shop_id=%s actual_shop_id=%s resolved_shop_id=%s metric_date=%s",
-                target_shop_id,
-                actual_shop_id,
-                resolved_shop_id,
-                metric_day_text,
-            )
-            return
-        if actual_shop_id != target_shop_id:
-            logger.warning(
-                "skip dashboard persistence due to shop mismatch: target_shop_id=%s actual_shop_id=%s resolved_shop_id=%s metric_date=%s",
-                target_shop_id,
-                actual_shop_id,
-                resolved_shop_id,
-                metric_day_text,
-            )
-            return
-        source = str(payload.get("source", "script"))
-        await repo.upsert_score(
-            shop_id=resolved_shop_id,
-            metric_date=metric_day,
-            total_score=float(payload.get("total_score", 0.0)),
-            product_score=float(payload.get("product_score", 0.0)),
-            logistics_score=float(payload.get("logistics_score", 0.0)),
-            service_score=float(payload.get("service_score", 0.0)),
-            bad_behavior_score=float(payload.get("bad_behavior_score", 0.0)),
-            shop_name=str(payload.get("shop_name", "")).strip() or None,
-            source=source,
+        persister = CollectionResultPersister()
+        await persister.persist(
+            session=db_session,
+            runtime=runtime,
+            metric_date=metric_date,
+            payload=payload,
         )
 
-        reviews = payload.get("reviews", {}).get("items", [])
-        review_rows = []
-        for review in reviews:
-            review_rows.append(
-                {
-                    "review_id": review.get("id") or review.get("review_id") or "",
-                    "content": review.get("content") or "",
-                    "is_replied": bool(review.get("shop_reply")),
-                    "source": source,
-                }
-            )
-        await repo.replace_reviews(
-            shop_id=resolved_shop_id,
-            metric_date=metric_day,
-            reviews=review_rows,
-        )
 
-        violations = _extract_violation_items(payload)
-        violation_rows = []
-        for item in violations:
-            violation_rows.append(
-                {
-                    "violation_id": item.get("ticket_id")
-                    or item.get("ticketId")
-                    or item.get("id")
-                    or item.get("rule_id")
-                    or item.get("penalty_id")
-                    or item.get("rule")
-                    or "",
-                    "violation_type": item.get("type")
-                    or item.get("rule_type")
-                    or item.get("violation_type")
-                    or item.get("penalty_type")
-                    or "unknown",
-                    "description": item.get("description")
-                    or item.get("reason")
-                    or item.get("rule"),
-                    "score": _to_int(
-                        item.get("score")
-                        or item.get("deduct_score")
-                        or item.get("deductScore")
-                        or item.get("point")
-                        or item.get("points")
-                        or 0
-                    ),
-                    "source": source,
-                }
-            )
-        await repo.replace_violations(
-            shop_id=resolved_shop_id,
-            metric_date=metric_day,
-            violations=violation_rows,
-        )
-        await db_session.commit()
-
-
-def _extract_violation_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
-    violations = payload.get("violations")
-    if isinstance(violations, dict):
-        direct = _normalize_violation_items(violations.get("waiting_list"))
-        if direct:
-            return direct
-
-    raw = payload.get("raw")
-    if isinstance(raw, dict):
-        raw_violations = raw.get("violations")
-        if isinstance(raw_violations, dict):
-            extracted = extract_nested_list(raw_violations.get("waiting_list"))
-            fallback = _normalize_violation_items(extracted)
-            if fallback:
-                return fallback
-
-    return []
-
-
-def _normalize_violation_items(value: Any) -> list[dict[str, Any]]:
-    if not isinstance(value, list):
-        return []
-    rows: list[dict[str, Any]] = []
-    for item in value:
-        if isinstance(item, Mapping):
-            rows.append(dict(item))
-    return rows
-
-
-def _to_int(value: Any) -> int:
-    try:
-        return int(float(value))
-    except (TypeError, ValueError):
-        return 0
-
-
-def _normalize_shop_id(value: Any) -> str:
-    normalized = str(value or "").strip()
-    if not normalized:
-        return ""
-    if normalized.isdigit():
-        return str(int(normalized))
-    return normalized
+RateLimiter = _RateLimiter
+collect_one_day = _collect_one_day
+build_business_key = _build_business_key

--- a/tests/application/collection/test_result_persister.py
+++ b/tests/application/collection/test_result_persister.py
@@ -1,6 +1,7 @@
 from datetime import date
 from types import SimpleNamespace
 
+import pytest
 from sqlalchemy import select
 
 from src.application.collection.result_persister import CollectionResultPersister
@@ -61,7 +62,7 @@ async def test_persist_should_invalidate_experience_cache_after_commit(
     assert calls == [("1001", date(2026, 3, 3))]
 
 
-async def test_persist_should_not_fail_when_cache_invalidation_raises(
+async def test_persist_should_raise_when_cache_invalidation_raises(
     test_db,
     monkeypatch,
 ):
@@ -84,26 +85,27 @@ async def test_persist_should_not_fail_when_cache_invalidation_raises(
     try:
         async with test_db() as session:
             persister = CollectionResultPersister()
-            await persister.persist(
-                session=session,
-                runtime=SimpleNamespace(shop_id="1001"),
-                metric_date="2026-03-03",
-                payload={
-                    "shop_id": "1001",
-                    "target_shop_id": "1001",
-                    "actual_shop_id": "1001",
-                    "total_score": 80.0,
-                    "product_score": 82.0,
-                    "logistics_score": 78.0,
-                    "service_score": 81.0,
-                    "bad_behavior_score": 0.0,
-                    "shop_name": "demo-shop",
-                    "source": "script",
-                    "reviews": {"items": []},
-                    "violations": {"waiting_list": []},
-                    "raw": {},
-                },
-            )
+            with pytest.raises(RuntimeError, match="redis unavailable"):
+                await persister.persist(
+                    session=session,
+                    runtime=SimpleNamespace(shop_id="1001"),
+                    metric_date="2026-03-03",
+                    payload={
+                        "shop_id": "1001",
+                        "target_shop_id": "1001",
+                        "actual_shop_id": "1001",
+                        "total_score": 80.0,
+                        "product_score": 82.0,
+                        "logistics_score": 78.0,
+                        "service_score": 81.0,
+                        "bad_behavior_score": 0.0,
+                        "shop_name": "demo-shop",
+                        "source": "script",
+                        "reviews": {"items": []},
+                        "violations": {"waiting_list": []},
+                        "raw": {},
+                    },
+                )
             score = (
                 await session.execute(
                     select(ShopDashboardScore).where(

--- a/tests/scrapers/shop_dashboard/test_http_scraper.py
+++ b/tests/scrapers/shop_dashboard/test_http_scraper.py
@@ -212,6 +212,28 @@ def test_http_scraper_raises_when_login_expired():
             scraper.fetch_dashboard("shop-1", "2026-03-03")
 
 
+def test_http_scraper_raises_when_payload_reports_401():
+    from src.scrapers.shop_dashboard.http_scraper import HttpScraper
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith(
+            "/governance/shop/experiencescore/getOverviewByVersion"
+        ):
+            return httpx.Response(
+                200,
+                json={"code": 401, "message": "unauthorized"},
+            )
+        return httpx.Response(200, json={"code": 0, "data": {}})
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(
+        transport=transport, base_url="https://fxg.jinritemai.com"
+    ) as client:
+        scraper = HttpScraper(client=client, graphql_query="query X { __typename }")
+        with pytest.raises(LoginExpiredError):
+            scraper.fetch_dashboard("shop-1", "2026-03-03")
+
+
 def test_http_scraper_accepts_runtime_context():
     from src.scrapers.shop_dashboard.http_scraper import HttpScraper
 

--- a/tests/scrapers/shop_dashboard/test_http_scraper_error_handling.py
+++ b/tests/scrapers/shop_dashboard/test_http_scraper_error_handling.py
@@ -1,6 +1,7 @@
 import httpx
 import pytest
 
+from src.scrapers.shop_dashboard.exceptions import LoginExpiredError
 from src.scrapers.shop_dashboard.runtime import ShopDashboardRuntimeConfig
 from src.scrapers.shop_dashboard.exceptions import ShopDashboardScraperError
 
@@ -180,7 +181,7 @@ def test_request_retries_on_timeout_then_recovers(monkeypatch):
     assert calls["count"] == 2
 
 
-def test_request_does_not_retry_on_4xx(monkeypatch):
+def test_request_raises_login_expired_on_401_without_retry(monkeypatch):
     from src.scrapers.shop_dashboard import http_scraper as scraper_module
     from src.scrapers.shop_dashboard.http_scraper import HttpScraper
 
@@ -197,7 +198,7 @@ def test_request_does_not_retry_on_4xx(monkeypatch):
         transport=transport, base_url="https://fxg.jinritemai.com"
     ) as client:
         scraper = HttpScraper(client=client)
-        with pytest.raises(ShopDashboardScraperError) as exc_info:
+        with pytest.raises(LoginExpiredError) as exc_info:
             scraper.fetch_dashboard_with_context(runtime, "2026-03-03")
 
     assert exc_info.value.error_data["status_code"] == 401

--- a/tests/scrapers/shop_dashboard/test_login_state_manager_additional.py
+++ b/tests/scrapers/shop_dashboard/test_login_state_manager_additional.py
@@ -26,3 +26,16 @@ async def test_login_state_manager_returns_true_when_state_exists_and_refresh_ok
     mgr = LoginStateManager(state_store=store, refresh_checker=refresh_checker)
 
     assert await mgr.check_and_refresh("acct-2") is True
+
+
+async def test_login_state_manager_keeps_expired_status_after_mark_expired(tmp_path):
+    store = SessionStateStore(base_dir=tmp_path)
+    store.save("acct-3", {"cookies": [{"name": "sid", "value": "v3"}], "origins": []})
+    mgr = LoginStateManager(state_store=store)
+
+    await mgr.mark_expired("acct-3", reason="manual_expire")
+
+    assert await mgr.check_and_refresh("acct-3") is False
+    state = await mgr._get_state("acct-3")
+    assert state["status"] == "expired"
+    assert state["reason"] == "manual_expire"

--- a/tests/tasks/test_shop_dashboard_collection.py
+++ b/tests/tasks/test_shop_dashboard_collection.py
@@ -106,6 +106,20 @@ class _FakeLoginStateManager:
         self.state_store = state_store
         self.redis_client = redis_client
 
+    async def check_and_refresh(self, _account_id: str) -> bool:
+        return True
+
+    async def mark_expired(self, _account_id: str, reason: str) -> None:
+        _ = reason
+        return None
+
+
+class _RecordingLoginStateManager(_FakeLoginStateManager):
+    marked_expired: list[tuple[str, str]] = []
+
+    async def mark_expired(self, account_id: str, reason: str) -> None:
+        type(self).marked_expired.append((account_id, reason))
+
 
 class _FakeSessionBootstrapper:
     def __init__(self, state_store):
@@ -215,6 +229,49 @@ class _BootstrapVerifyRequestFailed:
             "bootstrap_verify_status": "failed",
             "bootstrap_verify_actual_shop_id": "",
             "bootstrap_verify_error_code": "verify_request_failed",
+        }
+
+
+class _BootstrapVerifyLoginExpired:
+    def __init__(self, state_store):
+        self.state_store = state_store
+
+    async def bootstrap_shops(
+        self,
+        *,
+        runtime,
+        shop_ids,
+        verify_metric_date_by_shop=None,
+        force_serial=None,
+    ):
+        _ = (runtime, verify_metric_date_by_shop, force_serial)
+        return {
+            str(shop_id): {
+                "shop_id": str(shop_id),
+                "target_shop_id": str(shop_id),
+                "bootstrap_failed": True,
+                "error_code": "verify_login_expired",
+                "error": "http_401",
+                "bootstrap_choose_status": "passed",
+                "bootstrap_verify_status": "failed",
+                "bootstrap_verify_actual_shop_id": "",
+                "bootstrap_verify_error_code": "verify_login_expired",
+            }
+            for shop_id in shop_ids
+        }
+
+    async def bootstrap_shop(self, *, runtime, shop_id, verify_metric_date=None):
+        _ = (runtime, shop_id, verify_metric_date)
+        return {
+            "shop_id": str(shop_id),
+            "target_shop_id": str(shop_id),
+            "bootstrap_failed": True,
+            "error_code": "verify_login_expired",
+            "error": "http_401",
+            "bootstrap_choose_status": "passed",
+            "bootstrap_verify_status": "failed",
+            "bootstrap_verify_actual_shop_id": "",
+            "bootstrap_verify_error_code": "verify_login_expired",
         }
 
 
@@ -631,6 +688,57 @@ async def test_bootstrap_verify_request_failed_not_counted_as_shop_mismatch(
     assert result["shop_mismatch_count"] == 0
     assert result["items"][0]["reason"] == "bootstrap_verify_failed"
     assert result["items"][0]["error_code"] == "verify_request_failed"
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_verify_login_expired_marks_login_state_expired(
+    test_db,
+    monkeypatch,
+):
+    _RecordingLoginStateManager.marked_expired = []
+    data_source_id, rule_id = await _seed_entities(test_db)
+    monkeypatch.setattr(
+        db_session_module,
+        "async_session_factory",
+        test_db,
+        raising=False,
+    )
+    monkeypatch.setattr(module, "SessionStateStore", _FakeStateStore)
+    monkeypatch.setattr(
+        module,
+        "SessionBootstrapper",
+        _BootstrapVerifyLoginExpired,
+        raising=False,
+    )
+    monkeypatch.setattr(module, "LockManager", _FakeLockManager)
+    monkeypatch.setattr(module, "LoginStateManager", _RecordingLoginStateManager)
+    monkeypatch.setattr(
+        module,
+        "_materialize_runtime_storage_state",
+        lambda runtime, _store: runtime,
+    )
+    monkeypatch.setattr(
+        CollectionUseCase,
+        "_raise_when_all_units_failed",
+        lambda self, result: None,
+    )
+
+    usecase = CollectionUseCase()
+    result = await usecase._execute_async(
+        data_source_id=data_source_id,
+        rule_id=rule_id,
+        execution_id="exec-bootstrap-login-expired",
+        queue_task_id="queue-bootstrap-login-expired",
+        triggered_by=1,
+        overrides={},
+        redis_client=_FakeRedis(),
+    )
+
+    assert result["bootstrap_verify_failed_count"] == 1
+    assert result["items"][0]["error_code"] == "verify_login_expired"
+    assert _RecordingLoginStateManager.marked_expired == [
+        (f"rule_{rule_id}", "verify_login_expired")
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related Issue

Closes # N/A

## Summary of Changes

- Enforced login state validation before shop dashboard scraping starts, and marked sessions as expired when login-related scraper errors occur.
- Made the shop dashboard runtime state directory configurable through `shop_dashboard.runtime_state_dir` instead of relying on a fixed path.
- Changed result persistence to propagate cache invalidation failures after database commit, avoiding silent stale-cache success cases.
- Added more resilient task module symbol resolution and invocation fallback logic in the collection executor for rate limiter, business key builder, and collection entrypoint loading.
- Exposed public collection entry point aliases and removed remaining legacy persistence drift in the task module path.

## Breaking Changes

N/A

## Checklist

- [ ] Issue discussion completed before opening PR
- [x] Scope is small and focused (single feature/fix)
- [x] All functions have full type annotations
- [x] Async/await used for all I/O operations
- [ ] Tests added for new behaviors
